### PR TITLE
Allow free-form hex movement and upscale tiles

### DIFF
--- a/server/src/world/gameWorld.ts
+++ b/server/src/world/gameWorld.ts
@@ -1,12 +1,5 @@
 import { logger } from '../logger';
-import {
-  AxialCoordinate,
-  HexDirection,
-  HEX_DIRECTION_VECTORS,
-  axialToOffset,
-  addAxial,
-  offsetToAxial,
-} from './hex';
+import { AxialCoordinate, axialToOffset, offsetToAxial } from './hex';
 import { HexGrid, SerializedHexGrid } from './hexGrid';
 
 export interface PlayerState {
@@ -65,24 +58,22 @@ export class GameWorld {
     }
   }
 
-  movePlayer(id: string, direction: HexDirection): SerializedPlayerState | null {
+  movePlayerTo(id: string, target: AxialCoordinate): SerializedPlayerState | null {
     const player = this.players.get(id);
     if (!player) {
       return null;
     }
 
-    const vector = HEX_DIRECTION_VECTORS[direction];
-    const candidate = addAxial(player.position, vector);
-    if (!this.grid.isInsideAxial(candidate)) {
+    if (!this.grid.isInsideAxial(target)) {
       return null;
     }
 
-    const tile = this.grid.getTileByAxial(candidate);
+    const tile = this.grid.getTileByAxial(target);
     if (!tile || !tile.walkable) {
       return null;
     }
 
-    player.position = candidate;
+    player.position = { ...target };
     return this.serializePlayer(player);
   }
 

--- a/server/src/world/hex.ts
+++ b/server/src/world/hex.ts
@@ -37,6 +37,14 @@ export function isHexDirection(value: unknown): value is HexDirection {
   return typeof value === 'string' && value in HEX_DIRECTION_VECTORS;
 }
 
+export function isAxialCoordinate(value: unknown): value is AxialCoordinate {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  const candidate = value as Partial<AxialCoordinate>;
+  return Number.isInteger(candidate.q) && Number.isInteger(candidate.r);
+}
+
 export function addAxial(
   a: AxialCoordinate,
   b: AxialCoordinate


### PR DESCRIPTION
## Summary
- allow clients to request movement to any hex by sending axial targets and validating them on the server
- enlarge the rendered hex grid, highlights, and fallback visuals for a clearer playfield
- stretch player movement animations based on travel distance so long moves stay animated

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e17e11e268832ca1aede6cc41f8e4f